### PR TITLE
Fix AM_MAINTAINER_MODE as per guidelines

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3,7 +3,7 @@
 AC_INIT([hfp4linux], [0.1.0], [samr7@cs.washington.edu])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
-AM_MAINTAINER_MODE
+AM_MAINTAINER_MODE([enable])
 
 DX_HTML_FEATURE(ON)
 DX_CHM_FEATURE(OFF)


### PR DESCRIPTION
This shouldn't be the default mode, as universely agreed upon by
distributions.  It means that modifications to Makefile.am are not
automatically detected.  AM_MAINTAINER_MODE([enable]) is the recommended
solution, which disables it unless explicity requested during a
configure.
