### PR TITLE
Fix dbus - it has bitrotted over the years

### DIFF
--- a/hfpd/dbus.cpp
+++ b/hfpd/dbus.cpp
@@ -1485,10 +1485,16 @@ DbusDispatch(DBusMessage *msgp)
 	assert(!strcmp(dbus_message_get_path(msgp), m_path));
 
 	ifname = dbus_message_get_interface(msgp);
-	ifp = DbusFindInterface(m_ifaces, ifname);
-	if (!ifp) {
-		ifp = DbusFindInterface(s_ifaces_common, ifname);
-		if (!ifp)
+	if(ifname) {
+		ifp = DbusFindInterface(m_ifaces, ifname);
+		if (!ifp) {
+			ifp = DbusFindInterface(s_ifaces_common, ifname);
+			if (!ifp)
+				return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+		}
+	} else {
+		ifp = m_ifaces;
+		if(!ifp)
 			return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 	}
 	methp = DbusFindMethod(ifp->if_meths, dbus_message_get_member(msgp));


### PR DESCRIPTION
Without the fix, running any dbus command made it crash.  E.g:

qdbus net.sf.nohands.hfpd /net/sf/nohands/hfpd Start
