### PR TITLE
Add a SendAtCommand dbus function to just pass a given AT string

### DIFF
--- a/hfpd/objects.h
+++ b/hfpd/objects.h
@@ -85,6 +85,7 @@ class AudioGateway : public HfpdExportObject {
 
 	bool DoSetAutoReconnect(bool value, libhfp::ErrorInfo *error = 0);
 
+	void AtCommandComplete(class AgPendingCommand *agpcp, void *result);
 	void QueryNumberComplete(class AgPendingCommand *agpcp, void *result);
 	void QueryOperatorComplete(class AgPendingCommand *agpcp,
 				   void *result);
@@ -133,6 +134,7 @@ public:
 	bool CloseAudio(DBusMessage *msgp);
 	bool Dial(DBusMessage *msgp);
 	bool Redial(DBusMessage *msgp);
+	bool SendAtCommand(DBusMessage *msgp);
 	bool HangUp(DBusMessage *msgp);
 	bool SendDtmf(DBusMessage *msgp);
 	bool Answer(DBusMessage *msgp);
@@ -177,6 +179,7 @@ static const DbusMethod g_AudioGateway_methods[] = {
 	DbusMethodEntry(AudioGateway, CloseAudio, "", ""),
 	DbusMethodEntry(AudioGateway, Dial, "s", ""),
 	DbusMethodEntry(AudioGateway, Redial, "", ""),
+	DbusMethodEntry(AudioGateway, SendAtCommand, "s", "s"),
 	DbusMethodEntry(AudioGateway, HangUp, "", ""),
 	DbusMethodEntry(AudioGateway, SendDtmf, "y", ""),
 	DbusMethodEntry(AudioGateway, Answer, "", ""),

--- a/include/libhfp/hfp.h
+++ b/include/libhfp/hfp.h
@@ -450,12 +450,18 @@ public:
 };
 
 class GsmResult {
-protected:
+public:
 	char		*src_string;
+protected:
 	size_t		extra;
 	void *operator new(size_t nb, const char *src_string, size_t len);
 public:
 	void operator delete(void *mem);
+};
+
+class GenericAtCommandResult : public GsmResult {
+public:
+	static GenericAtCommandResult *Parse(const char *buffer);
 };
 
 class GsmClipResult : public GsmResult {
@@ -1576,6 +1582,20 @@ public:
 	 * connection was lost or the phone number is too long
 	 */
 	HfpPendingCommand *CmdDial(const char *phnum, ErrorInfo *error = 0);
+
+	/**
+	 * @brief Run a generic AT command
+	 *
+	 * @param[in] AtCmd AT command to call
+	 * @param[out] error Error information structure.  If this method
+	 * fails and returns @c 0, and @em error is not 0, @em error
+	 * will be filled out with information on the cause of the failure.
+	 * @return An HfpPendingCommand to receive a notification when
+	 * the command completes, with the command status, or @c 0 if
+	 * the command could not be queued, e.g. because the device
+	 * connection was lost or the phone number is too long
+	 */
+	HfpPendingCommand *CmdGenericAtCommand(const char *atCmd, ErrorInfo *error = 0);
 
 	/**
 	 * @brief Request that the audio gateway place a new outgoing call


### PR DESCRIPTION
This is useful for testing or running custom/proprietary AT commands

For example:

$ qdbus net.sf.nohands.hfpd /net/sf/nohands/hfpd AddDevice "22:22:68:4B:0F:06" "true" 
$ qdbus net.sf.nohands.hfpd /net/sf/nohands/hfpd/22_22_68_4B_0F_06 Connect
$ qdbus net.sf.nohands.hfpd /net/sf/nohands/hfpd/22_22_68_4B_0F_06 SendAtCommand "AT+CHLD=?"
+CHLD: (0,1,2,3)
